### PR TITLE
Add Requesty as an AI integration provider

### DIFF
--- a/app/services/ai/base_service.rb
+++ b/app/services/ai/base_service.rb
@@ -126,6 +126,11 @@ module Ai
           when 'open_router'
             # RubyLLM has native OpenRouter support
             config.openrouter_api_key = @integration.credential(:api_key)
+          when 'requesty'
+            # Requesty exposes an OpenAI-compatible API, so we point RubyLLM's
+            # OpenAI client at the Requesty router base URL.
+            config.openai_api_key = @integration.credential(:api_key)
+            config.openai_api_base = Integrations::Providers::Requesty::API_BASE_URL
           end
         else
           # Fall back to ENV variables

--- a/app/services/integrations/providers/requesty.rb
+++ b/app/services/integrations/providers/requesty.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Providers
+    # Requesty integration provider.
+    #
+    # Provides unified access to 400+ AI models from multiple providers
+    # (Anthropic, OpenAI, Google, DeepSeek, etc.) through a single
+    # OpenAI-compatible API.
+    #
+    # Requesty exposes an OpenAI-compatible API, so we configure RubyLLM
+    # with the Requesty API key and base URL.
+    #
+    # Required credentials:
+    # - api_key: Requesty API key from app.requesty.ai/api-keys
+    #
+    # Settings:
+    # - default_model: Which model to use (in provider/model format)
+    # - max_tokens: Maximum tokens in response
+    #
+    class Requesty < Base
+      self.category = :ai
+      self.display_name = 'Requesty'
+      self.description = 'Access 400+ AI models from multiple providers through a single OpenAI-compatible API'
+
+      API_BASE_URL = 'https://router.requesty.ai/v1'
+
+      # Popular models available through Requesty
+      # Format: [Display Name, provider/model-id]
+      AVAILABLE_MODELS = [
+        ['Claude Sonnet 4.5 (Anthropic)', 'anthropic/claude-sonnet-4-5'],
+        ['GPT-4o (OpenAI)', 'openai/gpt-4o'],
+        ['GPT-4o Mini (OpenAI)', 'openai/gpt-4o-mini'],
+        ['GPT-4.1 (OpenAI)', 'openai/gpt-4.1'],
+        ['Gemini 2.5 Flash (Google)', 'google/gemini-2.5-flash'],
+        ['Gemini 2.5 Pro (Google)', 'google/gemini-2.5-pro'],
+        ['DeepSeek Chat (DeepSeek)', 'deepseek/deepseek-chat']
+      ].freeze
+
+      credential_field :api_key,
+                       required: true,
+                       label: 'API Key',
+                       help: 'Get your API key from app.requesty.ai/api-keys'
+
+      setting_field :default_model,
+                    type: :select,
+                    options: AVAILABLE_MODELS,
+                    default: 'openai/gpt-4o-mini',
+                    label: 'Default Model',
+                    help: 'The model to use for content generation'
+
+      setting_field :max_tokens,
+                    type: :number,
+                    default: 4096,
+                    label: 'Max Tokens',
+                    help: 'Maximum number of tokens in generated responses'
+
+      def validate_connection
+        unless credentials_valid?
+          errors.add(:base, 'API key is required')
+          return false
+        end
+
+        # Validate by fetching the models list from Requesty
+        response = Faraday.get("#{API_BASE_URL}/models") do |req|
+          req.headers['Authorization'] = "Bearer #{credential(:api_key)}"
+          req.options.timeout = 10
+        end
+
+        if response.status == 401
+          errors.add(:base, 'Invalid API key')
+          return false
+        end
+
+        response.success?
+      rescue Faraday::Error => e
+        errors.add(:base, "Connection failed: #{e.message}")
+        false
+      rescue StandardError => e
+        errors.add(:base, "Connection failed: #{e.message}")
+        false
+      end
+    end
+  end
+end
+
+# Register with the integrations registry
+Integrations::Registry.register(:ai, :requesty, Integrations::Providers::Requesty)

--- a/docs/ai_features/requesty_integration.md
+++ b/docs/ai_features/requesty_integration.md
@@ -1,0 +1,188 @@
+# Requesty Integration
+
+## Overview
+
+[Requesty](https://requesty.ai) is an API router that provides unified access to 400+ AI models from multiple providers (Anthropic, OpenAI, Google, DeepSeek, and more) through a single OpenAI-compatible API endpoint.
+
+## Why Requesty?
+
+| Benefit | Description |
+|---------|-------------|
+| **Model Variety** | Access Claude, GPT-4o, Gemini, DeepSeek, and 400+ other models |
+| **Single API Key** | One API key for all providers |
+| **Cost Optimization** | Compare pricing across providers, pay-as-you-go |
+| **Automatic Fallbacks** | Route to backup models if primary is unavailable |
+| **No Provider Lock-in** | Switch models without code changes |
+
+## Configuration
+
+### Site Admin Setup
+
+1. Navigate to **Site Admin > Integrations**
+2. Click **Configure** next to Requesty
+3. Enter your API key from [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys)
+4. Select a default model
+5. Click **Save**
+
+### Credentials
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| API Key | Yes | Your Requesty API key |
+
+### Settings
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| Default Model | Select | `openai/gpt-4o-mini` | Model used for AI generation |
+| Max Tokens | Number | 4096 | Maximum response length |
+
+## Available Models
+
+Requesty provides access to models in the format `provider/model-name`:
+
+### Recommended Models
+
+| Model | Provider | Best For |
+|-------|----------|----------|
+| `anthropic/claude-sonnet-4-5` | Anthropic | General purpose, good balance of quality/cost |
+| `openai/gpt-4o` | OpenAI | Fast, multimodal |
+| `openai/gpt-4o-mini` | OpenAI | Cost-effective, good quality |
+| `openai/gpt-4.1` | OpenAI | High quality, large context |
+| `google/gemini-2.5-flash` | Google | Fast, multimodal |
+| `google/gemini-2.5-pro` | Google | Long context, multimodal |
+| `deepseek/deepseek-chat` | DeepSeek | Cost-effective, strong reasoning |
+
+### Full Model List
+
+See [requesty.ai](https://requesty.ai) for the complete list of available models with pricing.
+
+## Technical Implementation
+
+### API Compatibility
+
+Requesty uses an **OpenAI-compatible API**, which means:
+- Same request/response format as OpenAI
+- Uses `https://router.requesty.ai/v1` as the base URL
+- Works with existing OpenAI client libraries
+
+### RubyLLM Configuration
+
+PropertyWebBuilder uses RubyLLM for AI interactions. Requesty integration works by:
+
+```ruby
+RubyLLM.configure do |config|
+  config.openai_api_key = requesty_api_key
+  config.openai_api_base = 'https://router.requesty.ai/v1'
+end
+```
+
+### Service Layer Integration
+
+The `Ai::BaseService` automatically handles Requesty configuration:
+
+```ruby
+# In app/services/ai/base_service.rb
+case @integration.provider
+when 'requesty'
+  config.openai_api_key = @integration.credential(:api_key)
+  config.openai_api_base = 'https://router.requesty.ai/v1'
+end
+```
+
+## Usage in AI Services
+
+All AI services automatically use the configured provider:
+
+```ruby
+# Listing Description Generation
+result = Ai::ListingDescriptionGenerator.new(
+  property: property,
+  locale: 'en',
+  tone: 'professional'
+).generate
+
+# Social Post Generation
+result = Ai::SocialPostGenerator.new(
+  property: property,
+  platforms: [:instagram, :facebook],
+  category: :just_listed
+).generate
+```
+
+The service will use Requesty if it's the configured AI integration for the website.
+
+## Cost Tracking
+
+Requesty usage is tracked in `pwb_ai_generation_requests`:
+- `ai_provider`: 'requesty'
+- `ai_model`: The specific model used (e.g., 'openai/gpt-4o-mini')
+- `input_tokens`: Tokens in the prompt
+- `output_tokens`: Tokens in the response
+- `cost_cents`: Calculated cost based on model pricing
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `401 Unauthorized` | Invalid API key | Check API key in Site Admin |
+| `402 Payment Required` | Insufficient credits | Add credits at app.requesty.ai |
+| `429 Rate Limited` | Too many requests | Automatic retry with backoff |
+| `503 Model Unavailable` | Model temporarily down | Requesty auto-routes to fallback |
+
+## Testing
+
+### Factory Trait
+
+```ruby
+# In specs
+let!(:integration) { create(:pwb_website_integration, :requesty, website: website) }
+```
+
+### Connection Validation
+
+```ruby
+# Test connection in Site Admin
+POST /site_admin/integrations/:id/test_connection
+```
+
+## Multi-Tenant Support
+
+Each website can have its own Requesty configuration:
+- Separate API keys per website
+- Different default models per website
+- Independent usage tracking
+- Isolated error states
+
+## Security Considerations
+
+1. **API Key Storage**: Encrypted at rest in `pwb_website_integrations.credentials`
+2. **Data Transit**: All requests use HTTPS
+3. **Data Processing**: Requests routed through Requesty's servers
+4. **Compliance**: Review Requesty's privacy policy for data handling
+
+## Troubleshooting
+
+### "AI is not configured" Error
+
+1. Check integration is enabled in Site Admin > Integrations
+2. Verify API key is set correctly
+3. Test connection using the "Test Connection" button
+
+### Model Not Found
+
+1. Verify model name format: `provider/model-name`
+2. Check model availability at requesty.ai
+3. Ensure sufficient credits for the model
+
+### Slow Responses
+
+1. Consider using a faster model (e.g., `openai/gpt-4o-mini`)
+2. Reduce `max_tokens` setting
+3. Check Requesty status page for outages
+
+## Related Documentation
+
+- [AI Features Overview](./README.md)
+- [OpenRouter Integration](./openrouter_integration.md)
+- [Integrations System](../architecture/integrations.md)

--- a/spec/factories/pwb_website_integrations.rb
+++ b/spec/factories/pwb_website_integrations.rb
@@ -60,6 +60,13 @@ FactoryBot.define do
       settings { { 'default_model' => 'anthropic/claude-3.5-sonnet', 'max_tokens' => 4096 } }
     end
 
+    trait :requesty do
+      category { 'ai' }
+      provider { 'requesty' }
+      credentials { { 'api_key' => 'sk-rq-...2345' } }
+      settings { { 'default_model' => 'openai/gpt-4o-mini', 'max_tokens' => 4096 } }
+    end
+
     trait :spp do
       category { 'spp' }
       provider { 'single_property_pages' }

--- a/spec/services/integrations/providers/requesty_spec.rb
+++ b/spec/services/integrations/providers/requesty_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Providers::Requesty do
+  let(:website) { create(:pwb_website) }
+  let(:integration) { create(:pwb_website_integration, :requesty, website: website) }
+
+  describe 'class attributes' do
+    it 'has category :ai' do
+      expect(described_class.category).to eq(:ai)
+    end
+
+    it 'has display_name Requesty' do
+      expect(described_class.display_name).to eq('Requesty')
+    end
+
+    it 'has a description' do
+      expect(described_class.description).to be_present
+    end
+  end
+
+  describe 'API_BASE_URL' do
+    it 'points to the Requesty router endpoint' do
+      expect(described_class::API_BASE_URL).to eq('https://router.requesty.ai/v1')
+    end
+  end
+
+  describe 'credential fields' do
+    it 'requires api_key' do
+      expect(described_class.credential_fields[:api_key][:required]).to be true
+    end
+
+    it 'has help text for api_key' do
+      expect(described_class.credential_fields[:api_key][:help]).to include('requesty.ai')
+    end
+  end
+
+  describe 'setting fields' do
+    describe 'default_model' do
+      let(:field) { described_class.setting_fields[:default_model] }
+
+      it 'is a select field' do
+        expect(field[:type]).to eq(:select)
+      end
+
+      it 'has options in provider/model format' do
+        options = field[:options]
+        options.each do |label, value|
+          expect(value).to match(%r{^[a-z-]+/[a-z0-9.-]+$}i),
+            "Expected '#{value}' to be in provider/model format"
+        end
+      end
+
+      it 'includes Claude models' do
+        model_values = field[:options].map(&:last)
+        expect(model_values.any? { |m| m.include?('claude') }).to be true
+      end
+
+      it 'includes GPT models' do
+        model_values = field[:options].map(&:last)
+        expect(model_values.any? { |m| m.include?('gpt') }).to be true
+      end
+
+      it 'has a default value' do
+        expect(described_class.default_for(:default_model)).to be_present
+      end
+
+      it 'defaults to openai/gpt-4o-mini' do
+        expect(described_class.default_for(:default_model)).to eq('openai/gpt-4o-mini')
+      end
+    end
+
+    describe 'max_tokens' do
+      let(:field) { described_class.setting_fields[:max_tokens] }
+
+      it 'is a number field' do
+        expect(field[:type]).to eq(:number)
+      end
+
+      it 'defaults to 4096' do
+        expect(described_class.default_for(:max_tokens)).to eq(4096)
+      end
+    end
+  end
+
+  describe '#validate_connection' do
+    let(:provider_instance) do
+      described_class.new(integration)
+    end
+
+    context 'with valid credentials' do
+      before do
+        # Mock successful API call
+        stub_request(:get, 'https://router.requesty.ai/v1/models')
+          .with(headers: { 'Authorization' => 'Bearer sk-rq-...2345' })
+          .to_return(status: 200, body: '{"data": []}')
+      end
+
+      it 'returns true' do
+        expect(provider_instance.validate_connection).to be true
+      end
+    end
+
+    context 'with invalid API key' do
+      before do
+        stub_request(:get, 'https://router.requesty.ai/v1/models')
+          .to_return(status: 401, body: '{"error": "Invalid API key"}')
+      end
+
+      it 'returns false' do
+        expect(provider_instance.validate_connection).to be false
+      end
+
+      it 'adds an error' do
+        provider_instance.validate_connection
+        expect(provider_instance.errors[:base]).to include('Invalid API key')
+      end
+    end
+
+    context 'with network error' do
+      before do
+        stub_request(:get, 'https://router.requesty.ai/v1/models')
+          .to_raise(Faraday::ConnectionFailed.new('Connection refused'))
+      end
+
+      it 'returns false' do
+        expect(provider_instance.validate_connection).to be false
+      end
+
+      it 'adds an error with the message' do
+        provider_instance.validate_connection
+        expect(provider_instance.errors[:base].first).to include('Connection')
+      end
+    end
+
+    context 'without credentials' do
+      let(:integration) { create(:pwb_website_integration, :requesty, :without_credentials, website: website) }
+
+      it 'returns false' do
+        expect(provider_instance.validate_connection).to be false
+      end
+
+      it 'adds an error about missing API key' do
+        provider_instance.validate_connection
+        expect(provider_instance.errors[:base].first).to match(/api key/i)
+      end
+    end
+  end
+
+  describe 'integration with Ai::BaseService' do
+    let!(:integration) { create(:pwb_website_integration, :requesty, website: website) }
+
+    it 'can be looked up via website.integration_for' do
+      expect(website.integration_for(:ai)).to eq(integration)
+    end
+
+    it 'provides credentials to the service' do
+      expect(integration.credential(:api_key)).to eq('sk-rq-...2345')
+    end
+
+    it 'provides settings to the service' do
+      expect(integration.setting(:default_model)).to eq('openai/gpt-4o-mini')
+    end
+  end
+
+  describe 'registry registration' do
+    it 'is registered under the :requesty key for the :ai category' do
+      expect(Integrations::Registry.provider(:ai, :requesty)).to eq(described_class)
+    end
+  end
+
+  describe 'multi-tenant isolation' do
+    let(:website1) { create(:pwb_website) }
+    let(:website2) { create(:pwb_website) }
+    let!(:integration1) { create(:pwb_website_integration, :requesty, website: website1, credentials: { 'api_key' => 'key-1' }) }
+    let!(:integration2) { create(:pwb_website_integration, :requesty, website: website2, credentials: { 'api_key' => 'key-2' }) }
+
+    it 'each website has its own Requesty integration' do
+      expect(website1.integration_for(:ai).credential(:api_key)).to eq('key-1')
+      expect(website2.integration_for(:ai).credential(:api_key)).to eq('key-2')
+    end
+
+    it 'integrations are isolated' do
+      expect(website1.integrations).not_to include(integration2)
+      expect(website2.integrations).not_to include(integration1)
+    end
+  end
+end

--- a/spec/services/integrations/registry_spec.rb
+++ b/spec/services/integrations/registry_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Integrations::Registry do
     it 'returns all providers for a category' do
       providers = described_class.providers_for(:ai)
       expect(providers).to be_a(Hash)
-      expect(providers).to include(:anthropic, :openai, :open_router)
+      expect(providers).to include(:anthropic, :openai, :open_router, :requesty)
     end
 
     it 'returns empty hash for unknown category' do
@@ -134,6 +134,65 @@ RSpec.describe Integrations::Registry do
       default = provider.default_for(:default_model)
       # Should be in provider/model format
       expect(default).to include('/')
+    end
+
+    it 'defines max_tokens setting' do
+      expect(provider.setting_fields[:max_tokens]).to be_present
+      expect(provider.default_for(:max_tokens)).to eq(4096)
+    end
+
+    it 'includes models from multiple providers in options' do
+      options = provider.setting_fields[:default_model][:options]
+      model_strings = options.map(&:last)
+
+      # Should include models from different providers
+      expect(model_strings.any? { |m| m.start_with?('anthropic/') }).to be true
+      expect(model_strings.any? { |m| m.start_with?('openai/') }).to be true
+    end
+  end
+
+  describe 'Requesty provider' do
+    let(:provider) { described_class.provider(:ai, :requesty) }
+
+    it 'is registered' do
+      expect(provider).to eq(Integrations::Providers::Requesty)
+    end
+
+    it 'has correct display name' do
+      expect(provider.display_name).to eq('Requesty')
+    end
+
+    it 'has correct category' do
+      expect(provider.category).to eq(:ai)
+    end
+
+    it 'has a description mentioning multiple models' do
+      expect(provider.description).to include('400+')
+    end
+
+    it 'defines required api_key credential' do
+      expect(provider.credential_fields[:api_key]).to be_present
+      expect(provider.credential_fields[:api_key][:required]).to be true
+    end
+
+    it 'api_key help text mentions requesty.ai' do
+      expect(provider.credential_fields[:api_key][:help]).to include('requesty.ai')
+    end
+
+    it 'uses the Requesty router base URL' do
+      expect(provider::API_BASE_URL).to eq('https://router.requesty.ai/v1')
+    end
+
+    it 'defines default_model setting' do
+      expect(provider.setting_fields[:default_model]).to be_present
+      expect(provider.setting_fields[:default_model][:type]).to eq(:select)
+    end
+
+    it 'has a sensible default model' do
+      default = provider.default_for(:default_model)
+      # Should be in provider/model format
+      expect(default).to include('/')
+      expect(default).to eq('openai/gpt-4o-mini')
     end
 
     it 'defines max_tokens setting' do


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as an AI provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router.

Changes:
- `app/services/integrations/providers/requesty.rb`: new `Requesty < Base` provider (auto-registers via the providers-dir glob), `API_BASE_URL = https://router.requesty.ai/v1`, verified model list, `validate_connection` hitting `/models`.
- `app/services/ai/base_service.rb`: OpenAI-compatible RubyLLM wiring for `requesty` (base URL + key), mirroring how OpenRouter is configured.
- specs + docs mirroring the OpenRouter ones.

Model naming is `provider/model`. Verified: `ruby -c` on the new files passes.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.